### PR TITLE
Linux-PAM: Switched to Meson build system per version 1.7.0.

### DIFF
--- a/linux-pam
+++ b/linux-pam
@@ -7,24 +7,14 @@ DEPS=""
 
 IDIR=$(cat << '~fin.'
 
-sed -e /service_DATA/d \
-    -i modules/pam_namespace/Makefile.am
-autoreconf -fi
-
-cm \
-    --sbindir=/usr/sbin                  \
-    --sysconfdir=/etc                    \
-    --libdir=/usr/lib                    \
-    --enable-securedir=/usr/lib/security \
-    --docdir=/tmp/rid/trash
+mn \
+    -D docs=disabled
 
 chmod -v 4755 /usr/sbin/unix_chkpwd
+rm -rvf /usr/lib/systemd
 
-32cm \
-    --sbindir=/usr/sbin                  \
-    --sysconfdir=/etc                    \
-    --host=i686-pc-linux-gnu             \
-    --enable-securedir=/usr/lib/security
+32mn \
+    -D docs=disabled
 
 install -vdm755 /etc/pam.d &&
 cat > /etc/pam.d/system-account << "EOF" &&


### PR DESCRIPTION
Linux-PAM-1.7.0 now uses the Meson build system. This PR switches to that build system and for rid, it is a simple change. Even on my main gaming rig system, the build succeeds for 32-bit with no issues, so no meson cross file necessary. GLFS reflects this change so I thought to change it here as well.